### PR TITLE
Исправлено название основной ветки в репе

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,11 +2,11 @@ name: Docker
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,11 +1,11 @@
 name: smoke-test
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
     pull_request:
       branches:
-        - master
+        - main
 
     workflow_dispatch:
     


### PR DESCRIPTION
Основная ветка называется `main`, а не `master`, соответственно все github actions должны триггериться на пуши в нее и пул реквесты нацеленные туда же