### PR TITLE
Исправил имя образа

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/clientportal
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-clientportal
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
Оказалось, при более внимательном чтении пайплайна, что имя образа содержит в себе имя аккаунта + имя репы. Придется использовать его, а компонент прописать через `-`