### PR TITLE
Логгирование через Serilog

### DIFF
--- a/Clientportal/src/DucksAgency.Spygame.Clientportal/DucksAgency.Spygame.Clientportal.csproj
+++ b/Clientportal/src/DucksAgency.Spygame.Clientportal/DucksAgency.Spygame.Clientportal.csproj
@@ -8,5 +8,18 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.Development.json">
+      <DependentUpon>appsettings.json</DependentUpon>
+    </Content>
+    <Content Update="appsettings.Compose.json">
+      <DependentUpon>appsettings.json</DependentUpon>
+    </Content>
+  </ItemGroup>
   
 </Project>

--- a/Clientportal/src/DucksAgency.Spygame.Clientportal/DucksAgency.Spygame.Clientportal.csproj
+++ b/Clientportal/src/DucksAgency.Spygame.Clientportal/DucksAgency.Spygame.Clientportal.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Clientportal/src/DucksAgency.Spygame.Clientportal/Program.cs
+++ b/Clientportal/src/DucksAgency.Spygame.Clientportal/Program.cs
@@ -1,7 +1,15 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((ctx, services, cfg) =>
+    cfg
+        .ReadFrom.Configuration(ctx.Configuration)
+        .ReadFrom.Services(services)
+        .Enrich.FromLogContext()
+);
 
 // Add services to the container.
 builder.Services.AddRazorPages();

--- a/Clientportal/src/DucksAgency.Spygame.Clientportal/Properties/launchSettings.json
+++ b/Clientportal/src/DucksAgency.Spygame.Clientportal/Properties/launchSettings.json
@@ -1,34 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:59428",
-      "sslPort": 44380
-    }
-  },
   "profiles": {
-    "http": {
+    "Development": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "http://localhost:5256",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7223;http://localhost:5256",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Clientportal/src/DucksAgency.Spygame.Clientportal/appsettings.Compose.json
+++ b/Clientportal/src/DucksAgency.Spygame.Clientportal/appsettings.Compose.json
@@ -1,0 +1,11 @@
+{
+  "DetailedErrors": true,
+  "Serilog": {
+    "WriteTo": [
+      {
+        "Name": "Seq",
+        "Args": { "serverUrl": "http://seq:5341" }
+      }
+    ]
+  }
+}

--- a/Clientportal/src/DucksAgency.Spygame.Clientportal/appsettings.Development.json
+++ b/Clientportal/src/DucksAgency.Spygame.Clientportal/appsettings.Development.json
@@ -1,9 +1,20 @@
 {
   "DetailedErrors": true,
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
+        }
+      }
+    ]
   }
 }

--- a/Clientportal/src/DucksAgency.Spygame.Clientportal/appsettings.json
+++ b/Clientportal/src/DucksAgency.Spygame.Clientportal/appsettings.json
@@ -1,8 +1,11 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog":{
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     }
   },
   "AllowedHosts": "*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+volumes:
+  seq-database:
+    
+services:
+  seq:
+    image: datalust/seq
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - "seq-database:/data"
+    environment:
+      - ACCEPT_EULA=Y
+        
+  clientportal:
+    build:
+      dockerfile: "Clientportal/Dockerfile"
+      context: "."
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: datalust/seq
     restart: unless-stopped
     ports:
-      - "80:80"
+      - "8080:80"
     volumes:
       - "seq-database:/data"
     environment:
@@ -16,5 +16,7 @@ services:
     build:
       dockerfile: "Clientportal/Dockerfile"
       context: "."
+    ports:
+      - "80:80"
     environment:
       - ASPNETCORE_ENVIRONMENT=Compose


### PR DESCRIPTION
### Логгирование в приложении
Добавил логгирование в проект. Фреймворк для логгирования - [Serilog](https://serilog.net/)
Чтобы логгирование было хорошим, следует опираться на несколько простых правил:
 - уровень сообщений по умолчанию - `Debug`
 - сообщения следует добавлять в точках ветвления алгоритма (`if-else`, `switch`, `try-catch`, в общем везде, где путь выполнения программы может измениться)
 - уровень `Information` предназначен для сообщений об изменении состояния (добавлена/изменена/удалена запись в БД, пользователь изменил текущее состояние в сеансе и т.д.)
 - уровень `Warning` предназначен для событий, потенциально грозящих проблемаи, но не приведших к некорректному поведению ПО
 - `Error` - для ошибок и исключительных ситуаций. То есть чисто технически появление сообщения на уровне `error` говорит о том что приложение "сломалось" и его надо чинить, дежурный инженер заводит инцидент, будит ответственных и вот это все.
О правильном логгировании недавно был [хороший разбор в подкасте RadioDotNet выпуск 67 01:10:20](https://radiodotnet.mave.digital/ep-67), там обозревали статью [Serilog Best Practicies](https://benfoster.io/blog/serilog-best-practices/)

### Seq
Добавил еще пример `docker-compose.yml` файла для запуска приложения локально. В случае окружения Compose логи будут отправлять в seq. Можно будет посмотреть их в браузере. Для локальной отладки и разработки самое простое решение, существенно проще чем поднимать ELK стек. 
Fixes #9 